### PR TITLE
Add execution permission to binaries modes

### DIFF
--- a/ohmyk8s.yaml
+++ b/ohmyk8s.yaml
@@ -118,7 +118,7 @@
       src: /tmp/sops
       remote_src: yes
       dest: /usr/local/bin/
-      mode: uo+x
+      mode: a+x
       owner: "{{ ansible_user }}"
       group: "{{ ansible_user }}"
 

--- a/ohmyk8s.yaml
+++ b/ohmyk8s.yaml
@@ -118,7 +118,7 @@
       src: /tmp/sops
       remote_src: yes
       dest: /usr/local/bin/
-      mode: u+x
+      mode: uo+x
       owner: "{{ ansible_user }}"
       group: "{{ ansible_user }}"
 
@@ -151,7 +151,7 @@
       src: /tmp/skaffold
       remote_src: yes
       dest: /usr/local/bin/
-      mode: u+x
+      mode: uo+x
       owner: "{{ ansible_user }}"
       group: "{{ ansible_user }}"
   - name: enable bash completion
@@ -180,7 +180,7 @@
       extra_opts:
         - "--add-file"
         - "k9s"
-      mode: u+x
+      mode: uo+x
       owner: "{{ ansible_user }}"
       group: "{{ ansible_user }}"
 
@@ -257,11 +257,11 @@
   - name: make kubectx script executable
     file:
       path: .kubectx/kubectx
-      mode: u+x
+      mode: uo+x
   - name: make kubens script executable
     file:
       path: .kubectx/kubens
-      mode: u+x
+      mode: uo+x
   - name: create kctx symbolic link
     become: yes
     file:

--- a/ohmyk8s.yaml
+++ b/ohmyk8s.yaml
@@ -151,7 +151,7 @@
       src: /tmp/skaffold
       remote_src: yes
       dest: /usr/local/bin/
-      mode: uo+x
+      mode: a+x
       owner: "{{ ansible_user }}"
       group: "{{ ansible_user }}"
   - name: enable bash completion
@@ -180,7 +180,7 @@
       extra_opts:
         - "--add-file"
         - "k9s"
-      mode: uo+x
+      mode: a+x
       owner: "{{ ansible_user }}"
       group: "{{ ansible_user }}"
 
@@ -257,11 +257,11 @@
   - name: make kubectx script executable
     file:
       path: .kubectx/kubectx
-      mode: uo+x
+      mode: a+x
   - name: make kubens script executable
     file:
       path: .kubectx/kubens
-      mode: uo+x
+      mode: a+x
   - name: create kctx symbolic link
     become: yes
     file:


### PR DESCRIPTION
Given multi users setup, the installed binaries like: `sops` can't be run by any other user than the user who installed them.
The fix is to permit all other users to run these binaries. 