### PR TITLE
Update k9s version

### DIFF
--- a/ohmyk8s.yaml
+++ b/ohmyk8s.yaml
@@ -174,7 +174,7 @@
   - name: download k9s
     become: yes
     unarchive:
-      src: https://github.com/derailed/k9s/releases/download/v0.25.18/k9s_Linux_x86_64.tar.gz
+      src: https://github.com/derailed/k9s/releases/download/v0.27.4/k9s_Linux_amd64.tar.gz
       remote_src: yes
       dest: /usr/local/bin/
       extra_opts:


### PR DESCRIPTION
As `v0.25.18` has a bug related to manually trigger cronjobs.

I faced the bug locally for a while but never found a reported bug for `v0.25.18` however i found reported bug for other version like [this](https://github.com/derailed/k9s/issues/1477), and [this](https://github.com/derailed/k9s/issues/1792).