### PR TITLE
Deprecate community.kubernetes in favor of using kubernetes.core

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The below are installed only on the `k8sdev` group:
 
 ## System requirements
 1. [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html?extIdCarryOver=true&sc_cid=701f2000001OH7YAAW) on your controller machine (e.g. laptop) which is typically different from, but could be the same as, the target machine you are preparing. You also need a couple of Ansible collections, install using the command:
-`ansible-galaxy collection install community.general community.kubernetes` (Make sure that you are using Ansible > v2.9)
+`ansible-galaxy collection install community.general kubernetes.core` (Make sure that you are using Ansible > v2.9)
 1. One or more SSH connections to the target machine(s) with public key authentication configured. You can do that by editing your `.ssh/config`. For example:
     ```bash
     # ~/.ssh/config

--- a/ohmyk8s.yaml
+++ b/ohmyk8s.yaml
@@ -138,7 +138,7 @@
     become: yes
     shell: 'helm completion bash >/etc/bash_completion.d/helm'
   - name: install helm-secrets plugin
-    community.kubernetes.helm_plugin:
+    kubernetes.core.helm_plugin:
       plugin_path: https://github.com/jkroepke/helm-secrets
       state: present
 
@@ -240,11 +240,11 @@
   hosts: k8sdev
   tasks:
   - name: add ingress-nginx repo
-    community.kubernetes.helm_repository:
+    kubernetes.core.helm_repository:
       name: ingress-nginx
       repo_url: "https://kubernetes.github.io/ingress-nginx"
   - name: deploy ingress-nginx chart 
-    community.kubernetes.helm:
+    kubernetes.core.helm:
       name: ingress-nginx
       chart_ref: ingress-nginx/ingress-nginx
       release_namespace: kube-system


### PR DESCRIPTION
Deprecate `community.kubernetes` in favor of using `kubernetes.core` as this will be removed from community.kubernetes 
in version 3.0.0.

```
[DEPRECATION WARNING]: community.kubernetes.helm_repository has been deprecated. The community.kubernetes collection is being renamed to kubernetes.core. Please update your FQCNs to kubernetes.core instead. This feature will be removed from 
community.kubernetes in version 3.0.0. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.