### PR TITLE
Add k8sdevdocker group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Oh My Kubernetes!
-An Ansible Playbook to automate the configuration of (Ubuntu Linux x86_64) machines
-to be ready for Kubernetes development. It cuts down the development
+An Ansible Playbook to automate the configuration of (Ubuntu Linux x86_64 and ARM64)
+machines to be ready for Kubernetes development. It cuts down the development
 environment preparation from tedious hours to less than 5 minutes.
 
 ## Included software
 
-The below are installed on both `k8sdev` and `k8sdevlite` groups:
+The below are installed on all groups (`k8sdev`, `k8sdevlite` and `k8sdevdocker`):
 
 - [git](https://git-scm.com/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
@@ -18,11 +18,14 @@ The below are installed on both `k8sdev` and `k8sdevlite` groups:
 - [kube-ps1](https://github.com/jonmosco/kube-ps1)
 - [tmux](https://tmuxcheatsheet.com/) and [.tmux](https://github.com/gpakosz/.tmux)
 - [kubectx/kubens](https://github.com/ahmetb/kubectx)
+- [docker-cli](https://docs.docker.com/engine/reference/commandline/cli/)
 
 All of the above come with bash completion, whenever applicable.
 
-The below are installed only on the `k8sdev` group:
+The below is installed on both `k8sdev` and `k8sdevdocker` groups:
 - [Docker Engine](https://docs.docker.com/engine/install/ubuntu/)
+
+The below are installed only on the `k8sdev` group:
 - [Kubernetes (microk8s)](https://microk8s.io/)
 - [ingress-nginx](https://kubernetes.github.io/ingress-nginx/)
 
@@ -50,6 +53,8 @@ containing all the machines you want to configure (yes you can configure many ma
     ...
     [k8sdevlite]
     ...
+    [k8sdevdocker]
+    ...
     ```
 
 The above file can be stored in the default location `/etc/ansible/hosts` if the control machine is running Debian/Ubuntu or a similar distro. For other distros or other operating systems, you can store it in any location then supply `--inventory <file-location>` to the `ansible-playbook` command.
@@ -74,9 +79,8 @@ awsdev1                     : ok=56   changed=7    unreachable=0    failed=0    
 ```
 
 ## Caveats
-- This only supports Ubuntu 20.04 running on x86_64 architectures.
+- This only supports Ubuntu running on either x86_64 or ARM64 architectures.
 Support for other distributions and architectures is possible but needs some work.
-For example, the `focal` distro is hard-coded in some lines and should be detected.
 
 ## Support
 If there are any errors from the above command, please create an issue in this repo or drop

--- a/inventory.ini
+++ b/inventory.ini
@@ -2,3 +2,5 @@
 # list machines in the inventory
 [k8sdevlite]
 # list machines in the inventory
+[k8sdevdocker]
+# list machines in the inventory

--- a/ohmyk8s.yaml
+++ b/ohmyk8s.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Detect target machine architecture
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   tasks:
     - name: Set global architecture variable based on target machine's architecture
       set_fact:
@@ -10,7 +10,7 @@
         msg: "Architecture for the target machine is set to: {{ target_mc_arch }}"
 
 - name: docker dependencies installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   become: true
   tasks:
   - name: install deps
@@ -38,7 +38,7 @@
       state: present
 
 - name: docker engine installer
-  hosts: k8sdev
+  hosts: k8sdev, k8sdevdocker
   become: true
   tasks:
   - name: install docker
@@ -70,7 +70,7 @@
       state: restarted
 
 - name: docker client installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   become: true
   tasks:
   - name: install docker client
@@ -109,7 +109,7 @@
       group: "{{ ansible_user }}"
 
 - name: kubectl installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   become: yes
   tasks:
   - name: snap installer
@@ -120,7 +120,7 @@
     shell: 'kubectl completion bash >/etc/bash_completion.d/kubectl'
 
 - name: sops installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   tasks:
   - name: download sops
     get_url: 
@@ -137,7 +137,7 @@
       group: "{{ ansible_user }}"
 
 - name: helm and helm plugins installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   tasks:
   - name: snap installer
     become: yes
@@ -152,7 +152,7 @@
       plugin_path: https://github.com/jkroepke/helm-secrets
       state: present
 - name: skaffold installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   tasks:
   - name: download skaffold
     get_url: 
@@ -182,7 +182,7 @@
         export SKAFFOLD_INSECURE_REGISTRY=localhost:32000 SKAFFOLD_DEFAULT_REPO=localhost:32000
 
 - name: k9s installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   tasks:
   - name: download k9s
     become: yes
@@ -198,7 +198,7 @@
       group: "{{ ansible_user }}"
 
 - name: azure-cli installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   become: true
   tasks:
   - name: install deps
@@ -231,14 +231,14 @@
       update_cache: yes
 
 - name: kubelogin installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   become: true
   tasks:
   - name: install kubectl (again) and kubelogin using azure-cli
     shell: 'az aks install-cli'
 
 - name: awscli installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   become: true
   tasks:
   - name: snap installer
@@ -266,7 +266,7 @@
               https: 30443
 
 - name: kube-ps1 installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   tasks:
   - name: git checkout
     git:
@@ -280,7 +280,7 @@
         source $HOME/.kube-ps1/kube-ps1.sh && PS1='\[\e]0;\u@\h: \w\a\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\] $(kube_ps1)\$ '
 
 - name: kubectx and kubens installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   tasks:
   - name: git checkout
     git:
@@ -320,7 +320,7 @@
       state: link
 
 - name: tmux installer
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   tasks:
   - name: install tmux
     become: yes
@@ -344,7 +344,7 @@
       dest: "{{ ansible_env.HOME }}/"
 
 - name: apt cleaner
-  hosts: k8sdev, k8sdevlite
+  hosts: k8sdev, k8sdevlite, k8sdevdocker
   tasks:
   - name: Remove dependencies that are no longer required and useless packages from the cache
     become: yes


### PR DESCRIPTION
This adds a new group called `k8sdevdocker` which behaves exactly like `k8sdevlite` in addition to installing the Docker Engine.